### PR TITLE
Additional tests and logging

### DIFF
--- a/job_runner/test_management_command.py
+++ b/job_runner/test_management_command.py
@@ -382,7 +382,7 @@ def test_signal_exit():
         main_thread = threading.main_thread().ident
         signal.pthread_kill(main_thread, signal.SIGTERM)
 
-    threading.Thread(target=send_term).start()
+    threading.Thread(target=send_term, name="Termination sender").start()
 
     call_command(
         "run_jobs",
@@ -436,7 +436,7 @@ def test_run_forever_timeout_race():
         time.sleep(2)
         run_forever_event.set()
 
-    threading.Thread(target=delay).start()
+    threading.Thread(target=delay, name="Event setter").start()
 
     with pytest.raises(SystemExit):
         # Call with an explicit stop timeout. This ensures our delay event fires to release

--- a/job_runner/test_timeout.py
+++ b/job_runner/test_timeout.py
@@ -64,6 +64,9 @@ def test_multiple_timeouts():
     tracker.add_timeout(timedelta(seconds=1), t_1.set)
     tracker.add_timeout(timedelta(seconds=10), t_2.set)
 
+    assert not t_1.is_set()
+    assert not t_2.is_set()
+
     time.sleep(2)
     assert t_1.is_set()
     assert not t_2.is_set()

--- a/job_runner/test_timeout.py
+++ b/job_runner/test_timeout.py
@@ -50,3 +50,23 @@ def test_basic_timeout():
     assert got_cancel.is_set()
     stop_event.set()  # Don't leave the thread hanging
     tracker.join()  # Make sure it exited
+
+
+def test_multiple_timeouts():
+    stop_event = Event()
+    tracker = TimeoutTracker(stop_event)
+    tracker.daemon = True
+    tracker.start()
+
+    t_1 = Event()
+    t_2 = Event()
+
+    tracker.add_timeout(timedelta(seconds=1), t_1.set)
+    tracker.add_timeout(timedelta(seconds=10), t_2.set)
+
+    time.sleep(2)
+    assert t_1.is_set()
+    assert not t_2.is_set()
+
+    stop_event.set()  # Don't leave the thread hanging
+    tracker.join()  # Make sure it exited

--- a/job_runner/timeouts.py
+++ b/job_runner/timeouts.py
@@ -64,6 +64,7 @@ class TimeoutTracker(Thread):
             self._log.debug("Running timeout tracker checks")
 
             with self._lock:
+                self._log.debug("Lock acquired for timeout tracker checks")
                 self._check_timeout_evt.clear()
                 self._fire_timeouts()
                 delay = self._next_timeout_delay


### PR DESCRIPTION
- Add a test for multiple parallel timeouts
- Make sure all threads are named
- Add some logging which will hopefully never be needed