### PR TITLE
Improve timeout tracker efficiency

### DIFF
--- a/job_runner/timeouts.py
+++ b/job_runner/timeouts.py
@@ -21,16 +21,6 @@ class TimeoutTracker(Thread):
 
         super().__init__(name="Timeout tracker")
 
-    def _watch_for_stop(self):
-        self._log.debug("Beginning stop watcher")
-        self._stop_evt.wait()
-        self._log.debug("Stop event fired, setting check timeout event")
-
-        with self._lock:
-            self._check_timeout_evt.set()
-
-        self._log.debug("Stop watcher finished")
-
     def add_timeout(self, duration: timedelta, callback: Callback) -> Callback:
         """Add a timeout to the callbacks"""
 
@@ -68,6 +58,16 @@ class TimeoutTracker(Thread):
             self._check_timeout_evt.wait(delay)
 
         self._log.info("Timeout watcher exiting")
+
+    def _watch_for_stop(self):
+        self._log.debug("Beginning stop watcher")
+        self._stop_evt.wait()
+        self._log.debug("Stop event fired, setting check timeout event")
+
+        with self._lock:
+            self._check_timeout_evt.set()
+
+        self._log.debug("Stop watcher finished")
 
     def _get_cancel(self, key: int) -> Callback:
         def cancel():

--- a/job_runner/timeouts.py
+++ b/job_runner/timeouts.py
@@ -70,6 +70,8 @@ class TimeoutTracker(Thread):
         self._log.debug("Stop watcher finished")
 
     def _get_cancel(self, key: int) -> Callback:
+        """Get a cancellation function for a given key"""
+
         def cancel():
             with self._lock:
                 if not key in self._running:
@@ -96,6 +98,8 @@ class TimeoutTracker(Thread):
 
     @property
     def _timeout_delay(self) -> Optional[float]:
+        """Figure out how long to delay until the next event"""
+
         next_timeout: Optional[float] = None
 
         for timeout, _ in self._running.values():


### PR DESCRIPTION
It looks like the hash of empty objects usually collides, which decreases the efficiency of the timeout tracker since it moves the key management from O(log n) to O(n). Switch to using an integer that is managed within the lock.