### PR TITLE
Enable flag to job registration

### DIFF
--- a/job_runner/management/commands/run_jobs.py
+++ b/job_runner/management/commands/run_jobs.py
@@ -95,6 +95,17 @@ class Command(BaseCommand):
             ),
         )
 
+        parser.add_argument(
+            "--print-jobs",
+            action="store_const",
+            const=True,
+            default=False,
+            help=(
+                "Print the list of jobs that have been computed. "
+                "Combine with --trial-run to see only the jobs that would be run."
+            ),
+        )
+
         return super().add_arguments(parser)
 
     def handle(
@@ -105,6 +116,7 @@ class Command(BaseCommand):
         include_jobs: List[str] = [],
         exclude_jobs: List[str] = [],
         trial_run: bool = False,
+        print_jobs: bool = False,
         *args,
         **kwargs,
     ):
@@ -155,6 +167,13 @@ class Command(BaseCommand):
 
         if not jobs_ok:
             sys.exit(1)
+
+        if print_jobs:
+            for job in sorted(jobs, key=lambda job: job.name):
+                print(job.name)
+                print(f"\tInterval: {job.interval}")
+                print(f"\tVariance: {job.variance}")
+                print(f"\tTimeout: {job.timeout}")
 
         if trial_run:
             return

--- a/job_runner/registration.py
+++ b/job_runner/registration.py
@@ -52,7 +52,7 @@ class RegisteredJob:
         return self._variance
 
     def check_callable_valid(self):
-        # We don't need a "real" stop event since we aren't callint the function
+        # We don't need a "real" stop event since we aren't calling the function
         sample_env, _ = get_environments(Event())
         signature = inspect.signature(self._func)
         # This will throw a type error if it isn't callable
@@ -66,11 +66,15 @@ def register_job(
     interval: AutoTime,
     variance: Optional[AutoTime] = None,
     timeout: Optional[AutoTime] = None,
+    enabled=True,
 ):
     """Decorator to schedule the job to be run every
     interval plus a random time up to variance"""
 
     def decorator(func: Job):
+        if not enabled:
+            return func
+
         return RegisteredJob(
             interval=auto_time(interval),
             variance=auto_time_default(variance, timedelta(0)),

--- a/job_runner/sample_jobs.py
+++ b/job_runner/sample_jobs.py
@@ -8,3 +8,8 @@ from job_runner.environment import RunEnv
 @register_job(5, 0)
 def sample_job_1(env: RunEnv):
     print(f"sample_job_1 is getting called at {datetime.now()}")
+
+
+@register_job(5, 0, enabled=False)
+def sample_job_disabled(env: RunEnv):
+    print(f"sample_job_disabled is getting called at {datetime.now()}")

--- a/job_runner/test_tracker.py
+++ b/job_runner/test_tracker.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 
-from .sample_jobs import sample_job_1
+from .sample_jobs import sample_job_1, sample_job_disabled
 from .registration import import_jobs_from_module
 
 
@@ -10,3 +10,8 @@ def test_explicit_jobs():
     jobs = import_jobs_from_module("job_runner.sample_jobs")
     assert sample_job_1 in jobs
     assert sample_job_1.interval == timedelta(seconds=5)
+
+
+def test_disabled_jobs():
+    jobs = import_jobs_from_module("job_runner.sample_jobs")
+    assert sample_job_disabled not in jobs


### PR DESCRIPTION
- Add a flag for job registration as to if the job is enabled
- Add a simple command to run_jobs to print the registered jobs regardless of logging config